### PR TITLE
opt parameter is actually optional now

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ module.exports = function (gulp, sep) {
 	var submodules = {};
 
 	gulp.submodule = function(submodule, opt) {
+		opt = opt || {};
+
 		var source;
 
 		if (opt.package || opt.pkg) {


### PR DESCRIPTION
The documentation stated the ‘options’ parameter for the submodule
function was optional. This was not actually the case because the check
on properties of that parameter were not guarded against it being
undefined and resulted in javascript errors being raised when left as
undefined.
